### PR TITLE
Closure's base path terminator check fails on Windows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 COMPILED = false;
 
 var path = require('path');
-var closureBasePath = path.join(__dirname, 'closure/goog/')
+var closureBasePath = __dirname + '/closure/goog/'
 var goog = require('closure').Closure({CLOSURE_BASE_PATH: closureBasePath});
 
 goog.require('goog.array');


### PR DESCRIPTION
In `node_modules/closure.js` the path `goog_.CLOSURE_BASE_PATH` is required to end with a `/` character.
Using `path.join` to compute the base path in `lib/index.js` causes the path to end with a `\` on Windows. Replacing `path.join` with concatenation solves the problem.

Tests pass on Windows 7 64-bit, Node 0.8.14
