### PR TITLE
Corrects jharlap contributor email address.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "mattbornski",
   "contributors": [
-    "Jonathan Harlap <jharlap at bic dot mni dot mcgill dot ca> (http://github.com/jharlap)",
+    "Jonathan Harlap <jharlap@gmail.com> (http://github.com/jharlap)",
     "Hans Malherbe <hans.malherbe@gmail.com> (http://github.com/hansmalherbe)",
     "Bryan Kreitlow <?> (http://github.com/bryankreitlow)",
     "Mike Belshe <mike@belshe.com> (https://github.com/mbelshe)"


### PR DESCRIPTION
Thanks for the mention in the contributors list, I just noticed that the email address you had found for me was an old one, so this corrects it.
