### PR TITLE
Expose PhoneNumberFormat class

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,5 +80,6 @@ var intl = function(number, countryCode, callback) {
 module.exports = {
   'e164': e164,
   'intl': intl,
+  'PhoneNumberFormat': PhoneNumberFormat,
   'phoneUtil': phoneUtil
 };


### PR DESCRIPTION
Expose `PhoneNumberFormat` class to allow call to `phoneUtil.format` method :

``` javascript
var libphonenumber = require('libphonenumber');

var PhoneNumberFormat = libphonenumber.PhoneNumberFormat;
var phoneUtil = libphonenumber.phoneUtil;

var phoneNumber = phoneUtil.parse('+33163765112', 'FR');

// 01 63 76 51 12
phoneNumber = phoneUtil.format(phoneNumber, PhoneNumberFormat.NATIONAL);
```
