### PR TITLE
Added a function to simply validate without formatting numbers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,15 +15,17 @@ goog.loadScript(closureBasePath + 'i18n/phonenumbers/phonenumber.pb.js');
 goog.loadScript(closureBasePath + 'i18n/phonenumbers/metadata.js');
 goog.loadScript(closureBasePath + 'i18n/phonenumbers/phonenumberutil.js');
 
-var phoneUtil = goog.global.i18n.phonenumbers.PhoneNumberUtil.getInstance();
-var PhoneNumberFormat = goog.global.i18n.phonenumbers.PhoneNumberFormat;
-var ValidationResult = goog.global.i18n.phonenumbers.PhoneNumberUtil.ValidationResult;
-var ValidationErrors = goog.global.i18n.phonenumbers.Error;
+var phonenumbers = goog.global.i18n.phonenumbers;
+var phoneUtil = phonenumbers.PhoneNumberUtil.getInstance();
+var PhoneNumber = phonenumbers.PhoneNumber;
+var PhoneNumberFormat = phonenumbers.PhoneNumberFormat;
+var ValidationResult = phonenumbers.PhoneNumberUtil.ValidationResult;
+var ValidationErrors = phonenumbers.Error;
 
-var formatNumber = function (number, countryCode, numberFormat, callback) {
+var validateNumber = function (number, countryCode) {
   var error = null;
   var result = null;
-  
+
   // Strip out everything that's not a phone number.
   if (number) {
     var potentialPhoneNumber = number.toString();
@@ -46,7 +48,7 @@ var formatNumber = function (number, countryCode, numberFormat, callback) {
           }
         } else {
           if (phoneUtil.isValidNumber(potentialPhoneNumber)) {
-            result = phoneUtil.format(potentialPhoneNumber, numberFormat);
+            result = potentialPhoneNumber
           } else {
             error = new Error('Invalid number');
           }
@@ -60,6 +62,47 @@ var formatNumber = function (number, countryCode, numberFormat, callback) {
   } else {
     error = new Error('No number given');
   }
+
+  if (error) {
+    throw error;
+  } else {
+    return result;
+  }
+};
+
+var formatNumber = function (number, countryCode, numberFormat, callback) {
+  var error = null;
+  var result = null;
+
+  try {
+    var validNumber = validateNumber(number, countryCode);
+    result = phoneUtil.format(validNumber, numberFormat);
+  }
+  catch (e) {
+    error = e
+  }
+
+  if (callback) {
+    callback(error, result);
+  } else if (error) {
+    throw error;
+  } else {
+    return result;
+  }
+};
+
+var validate = function (number, countryCode, callback) {
+  var error = null;
+  var result = null;
+
+  try {
+    var validNumber = validateNumber(number, countryCode);
+    result = validNumber instanceof PhoneNumber
+  }
+  catch (e) {
+    error = e
+  }
+
   if (callback) {
     callback(error, result);
   } else if (error) {
@@ -73,11 +116,12 @@ var e164 = function (number, countryCode, callback) {
   return formatNumber(number, countryCode, PhoneNumberFormat.E164, callback);
 };
 
-var intl = function(number, countryCode, callback) {
+var intl = function (number, countryCode, callback) {
   return formatNumber(number, countryCode, PhoneNumberFormat.INTERNATIONAL, callback);
 };
 
 module.exports = {
+  'validate': validate,
   'e164': e164,
   'intl': intl,
   'phoneUtil': phoneUtil


### PR DESCRIPTION
Formatting of comments might be a bit messy, but they're [shown inline here](https://github.com/jordansexton/libphonenumber/commit/e9c3efbe50aaeb6b4266dc4fbe1e293036c5e4cd).

I added and exposed a `validateNumber` function to validate the phone number without formatting it. Internally, it just extracts most of the logic from `formatNumber` which now delegates to `validateNumber`.